### PR TITLE
TV Yellow Xplo

### DIFF
--- a/pgk-x-tv-yellow.md
+++ b/pgk-x-tv-yellow.md
@@ -12,7 +12,7 @@
     - [ ] black pickguard
     - [ ] black cavity covers
 - [ ] Dark Phoenix — set Firebird style [pegcitypickups.com](https://www.pegcitypickups.com)
-- [ ] Resomax NW2 PS-8593-N0 | Wraparound · nickel · String Savers intégrés [graphtech.com](https://www.graphtech.com)
+- [x] Graph Tech Resomax NW2 PS-8593-N0 | Wraparound · nickel · String Savers intégrés [graphtech.com](https://www.graphtech.com)
 - [ ] Gotoh SDS510 6-inline from [nextgenguitars.ca](https://nextgenguitars.ca)
 - [ ] Graph Tech TUSQ Slotted Nut (PQ-6116-00) from [nextgenguitars.ca](https://nextgenguitars.ca)
 - [ ] Electronics & hardware from [long-mcquade.com](https://www.long-mcquade.com)


### PR DESCRIPTION
## TV Yellow Korina Explorer — Shopping List

- [ ] Precision Guitar Kits — kit Explorer Slab TV Yellow [precisionguitarkits.com](https://precisionguitarkits.com)
    - [ ] Kit
    - [ ] Glue Neck
    - [ ] black pickguard
    - [ ] black cavity covers
- [ ] traditional wind with Alnico 3 P90 [pegcitypickups.com](https://pegcitypickups.com/collections/single-coil/products/traditional-p90s)
- [x] Resomax NW2 PS-8593-N0 | Wraparound · nickel · String Savers intégrés [graphtech.com](https://www.graphtech.com)
- [ ] Gotoh SDS510 6-inline from [nextgenguitars.ca](https://nextgenguitars.ca)
- [ ] Graph Tech TUSQ Slotted Nut (PQ-6116-00) from [nextgenguitars.ca](https://nextgenguitars.ca)
- [ ] Electronics & hardware from [long-mcquade.com](https://www.long-mcquade.com)
    - [ ] 500K audio pots (CTS split shaft, audio taper)
    - [ ] Switchcraft #12010X toggle switch
    - [ ] Switchcraft #11 mono output jack
    - [ ] Strap buttons
    - [ ] Black Top Hat · silver reflector + dial pointer
    - [ ] Switchcraft black toggle tip
- [ ] Capacitors & wire from [amazon.ca](https://amazon.ca)
    - [ ] Sprague Orange Drop 715P 0.022 µF tone capacitors
    - [ ] Gavitt 22 AWG cloth pushback hook-up wire
- [x] Finishing supplies from [oxfordguitarsupply.com](https://www.oxfordguitarsupply.com)
    - [x] [Deluxe Finishing Kit TV Yellow](https://oxfordguitarsupply.com/product/aerosol-finishing-kit/)
    - [x] [Grain Filler 8oz (Oil Based)](https://oxfordguitarsupply.com/product/grain-filler-oil-based-8oz/)